### PR TITLE
#2 Ajout d'une capacité de sauvegarde et restauration d'un niveau brouillon

### DIFF
--- a/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/EditableLevel.java
+++ b/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/EditableLevel.java
@@ -11,7 +11,9 @@ public class EditableLevel {
 	private List<EditableAttack> attacks = new ArrayList<>();
 	private List<EditableTowerCapacity> towerCapacities = new ArrayList<>();
 
-	public EditableLevel() {
+	@SuppressWarnings("unused")
+	// For serialization
+	private EditableLevel() {
 	}
 	
 	public EditableLevel(LevelMetadata metadata, EditableMap editableMap, List<EditableAttack> attacks,

--- a/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/EditableLevel.java
+++ b/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/EditableLevel.java
@@ -11,6 +11,9 @@ public class EditableLevel {
 	private List<EditableAttack> attacks = new ArrayList<>();
 	private List<EditableTowerCapacity> towerCapacities = new ArrayList<>();
 
+	public EditableLevel() {
+	}
+	
 	public EditableLevel(LevelMetadata metadata, EditableMap editableMap, List<EditableAttack> attacks,
 			List<EditableTowerCapacity> towerCapacities) {
 		this.metadata = metadata;

--- a/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/EditableMap.java
+++ b/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/EditableMap.java
@@ -5,23 +5,27 @@ import java.util.List;
 
 public class EditableMap {
 
-    private int width;
-    private int height;
-    private List<EditablePath> paths = new ArrayList<>();
+	private int width;
+	private int height;
+	private List<EditablePath> paths = new ArrayList<>();
 
-    public EditableMap() {
+	@SuppressWarnings("unused")
+	// For serialization
+	private EditableMap() {
 	}
-    
-    public EditableMap(int width, int height) {
-        this.width = width;
-        this.height = height;
-    }
 
-    public void addPath(EditablePath path) {
-        paths.add(path);
-    }
+	public EditableMap(int width, int height) {
+		this.width = width;
+		this.height = height;
+	}
 
-    public List<EditablePath> paths() { return paths; }
+	public void addPath(EditablePath path) {
+		paths.add(path);
+	}
+
+	public List<EditablePath> paths() {
+		return paths;
+	}
 
 	public int getWidth() {
 		return width;
@@ -34,6 +38,5 @@ public class EditableMap {
 	public List<EditablePath> getPaths() {
 		return paths;
 	}
-    
-}
 
+}

--- a/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/EditableMap.java
+++ b/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/EditableMap.java
@@ -5,10 +5,13 @@ import java.util.List;
 
 public class EditableMap {
 
-    private final int width;
-    private final int height;
-    private final List<EditablePath> paths = new ArrayList<>();
+    private int width;
+    private int height;
+    private List<EditablePath> paths = new ArrayList<>();
 
+    public EditableMap() {
+	}
+    
     public EditableMap(int width, int height) {
         this.width = width;
         this.height = height;

--- a/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/EditableTowerCapacity.java
+++ b/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/EditableTowerCapacity.java
@@ -5,9 +5,12 @@ import java.util.List;
 
 public class EditableTowerCapacity {
 
-    private final String towerType;
+    private String towerType;
     private final List<TowerUpgrade> upgrades = new ArrayList<>();
 
+    public EditableTowerCapacity() {
+	}
+    
     public EditableTowerCapacity(String towerType) {
         this.towerType = towerType;
     }

--- a/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/LevelMetadata.java
+++ b/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/LevelMetadata.java
@@ -8,7 +8,9 @@ public class LevelMetadata {
 	private int startingMoney;
 	private int startingLives;
 
-	public LevelMetadata() {
+	@SuppressWarnings("unused")
+	// For serialization
+	private LevelMetadata() {
 	}
 	
 	public LevelMetadata(int levelId, String name, String description, int startingMoney,

--- a/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/LevelMetadata.java
+++ b/td-level-editor/td-level-editor-api/src/main/java/com/towerdefense/editor/api/model/LevelMetadata.java
@@ -2,20 +2,21 @@ package com.towerdefense.editor.api.model;
 
 public class LevelMetadata {
 
-	private final int levelId;
+	private int levelId;
 	private String name;
 	private String description;
-	private int recommendedDifficulty;
 	private int startingMoney;
 	private int startingLives;
 
-	public LevelMetadata(int levelId, String name, String description, int recommendedDifficulty, int startingMoney,
+	public LevelMetadata() {
+	}
+	
+	public LevelMetadata(int levelId, String name, String description, int startingMoney,
 			int startingLives) {
 		super();
 		this.levelId = levelId;
 		this.name = name;
 		this.description = description;
-		this.recommendedDifficulty = recommendedDifficulty;
 		this.startingMoney = startingMoney;
 		this.startingLives = startingLives;
 	}
@@ -40,14 +41,6 @@ public class LevelMetadata {
 	public LevelMetadata setDescription(String description) {
 		this.description = description;
 		return this;
-	}
-
-	public int getRecommendedDifficulty() {
-		return recommendedDifficulty;
-	}
-
-	public void setRecommendedDifficulty(int recommendedDifficulty) {
-		this.recommendedDifficulty = recommendedDifficulty;
 	}
 
 	public int getStartingMoney() {

--- a/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/exporter/EditableLevelExportService.java
+++ b/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/exporter/EditableLevelExportService.java
@@ -1,0 +1,22 @@
+package com.towerdefense.editor.core.exporter;
+
+import com.towerdefense.editor.api.model.EditableLevel;
+import com.towerdefense.editor.core.validation.EditableLevelValidationResult;
+import com.towerdefense.editor.core.validation.EditableLevelValidator;
+
+public class EditableLevelExportService {
+
+	private final EditableLevelValidator validator;
+	
+	public EditableLevelExportService(EditableLevelValidator validator) {
+		this.validator = validator;
+	}
+	
+	public void export(EditableLevel level) {
+		EditableLevelValidationResult validation = validator.validate(level);
+		if (!validation.isValid()) {
+			throw new IllegalStateException("Invalid level: " + validation.getErrors());
+		}
+	}
+	
+}

--- a/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/importer/EditableLevelImportService.java
+++ b/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/importer/EditableLevelImportService.java
@@ -1,0 +1,17 @@
+package com.towerdefense.editor.core.importer;
+
+import com.towerdefense.editor.api.model.EditableLevel;
+
+/**
+ * Rebuilds an EditableLevel from an engine LevelConfig.
+ * 
+ * This class performs no validation.
+ */
+public class EditableLevelImportService {
+
+	public EditableLevel importLevel(EditableLevel level) {
+		// later add some controls about external ids, etc.
+		return level;
+	}
+
+}

--- a/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/importer/LevelImportService.java
+++ b/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/importer/LevelImportService.java
@@ -24,7 +24,7 @@ public class LevelImportService {
 
 		// --- Metadata ---
 		LevelMetadata metadata = new LevelMetadata(config.getId(), "Imported level " + config.getId(),
-				"Imported from LevelConfig", 0, config.getStartingMoney(), config.getStartingLives());
+				"Imported from LevelConfig", config.getStartingMoney(), config.getStartingLives());
 
 		// --- Map ---
 		// Dimensions are not part of LevelConfig yet → default placeholder

--- a/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/persistence/EditableLevelJsonIO.java
+++ b/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/persistence/EditableLevelJsonIO.java
@@ -1,0 +1,22 @@
+package com.towerdefense.editor.core.persistence;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.towerdefense.editor.api.model.EditableLevel;
+
+public class EditableLevelJsonIO {
+
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	public void save(EditableLevel config, Path file) throws IOException {
+		mapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), config);
+	}
+
+	public EditableLevel load(Path file) throws IOException {
+		File file2 = file.toFile();
+		return mapper.readValue(file2, EditableLevel.class);
+	}
+}

--- a/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/persistence/LevelJsonIO.java
+++ b/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/persistence/LevelJsonIO.java
@@ -1,4 +1,4 @@
-package com.towerdefense.editor.core.exporter;
+package com.towerdefense.editor.core.persistence;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/validation/DefaultEditableLevelValidator.java
+++ b/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/validation/DefaultEditableLevelValidator.java
@@ -1,0 +1,14 @@
+package com.towerdefense.editor.core.validation;
+
+import com.towerdefense.editor.api.model.EditableLevel;
+
+public class DefaultEditableLevelValidator implements EditableLevelValidator {
+
+    @Override
+    public EditableLevelValidationResult validate(EditableLevel level) {
+        EditableLevelValidationResult result = new EditableLevelValidationResult();
+
+
+        return result;
+    }
+}

--- a/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/validation/EditableLevelValidationResult.java
+++ b/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/validation/EditableLevelValidationResult.java
@@ -1,0 +1,21 @@
+package com.towerdefense.editor.core.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EditableLevelValidationResult {
+
+    private final List<String> errors = new ArrayList<>();
+
+    public void addError(String error) {
+        errors.add(error);
+    }
+
+    public boolean isValid() {
+        return errors.isEmpty();
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+}

--- a/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/validation/EditableLevelValidator.java
+++ b/td-level-editor/td-level-editor-core/src/main/java/com/towerdefense/editor/core/validation/EditableLevelValidator.java
@@ -1,0 +1,9 @@
+package com.towerdefense.editor.core.validation;
+
+import com.towerdefense.editor.api.model.EditableLevel;
+
+public interface EditableLevelValidator {
+
+	EditableLevelValidationResult validate(EditableLevel level);
+	
+}

--- a/td-level-editor/td-level-editor-ui/src/main/java/com/towerdefense/leveleditor/ui/EditorCli.java
+++ b/td-level-editor/td-level-editor-ui/src/main/java/com/towerdefense/leveleditor/ui/EditorCli.java
@@ -19,14 +19,15 @@ public class EditorCli {
 			System.out.println("You can either start a new level, load an existing one, or leave.");
 			System.out.println("1. New Level");
 			System.out.println("2. Load Level");
-			System.out.println("3. Exit application");
+			System.out.println("3. Load DRAFT Level");
+			System.out.println("4. Exit application");
 
 			System.out.println("Your choice ? (integer)");
 			String cmd = scanner.nextLine();
 			switch (cmd) {
 			case "1" -> {
 				System.out.println("Starting a new Level...");
-				LevelPrimaryData data = initialize();
+				LevelPrimaryData data = initialize(scanner);
 				controller.createNewLevel(data);
 				this.continueCreation(controller);
 			}
@@ -36,7 +37,13 @@ public class EditorCli {
 					System.out.println("Loading failed.");
 				}
 			}
-			case "3" -> System.exit(0);
+			case "3" -> {
+				System.out.println("Loading an existing DRAFT Level...");
+				if (!this.loadDraft(controller, scanner)) {
+					System.out.println("Loading failed.");
+				}
+			}
+			case "4" -> System.exit(0);
 			default -> System.out.println("Unknown command");
 			}
 		}
@@ -49,21 +56,35 @@ public class EditorCli {
 			System.out.println("Available commands:");
 			System.out.println("1. show");
 			System.out.println("2. add path");
-			System.out.println("3. save");
-			System.out.println("4. exit level editing session (all unsaved changes will be lost)");
+			System.out.println("3. save this draft");
+			System.out.println("4. save as exportable level");
+			System.out.println("5. exit level editing session (all unsaved changes will be lost)");
 			System.out.println("Your choice ? (integer)");
 			String cmd = scanner.nextLine();
 
 			switch (cmd) {
 			case "1" -> controller.printLevel();
 			case "2" -> addPath(controller, scanner);
-			case "3" -> save(controller, scanner);
-			case "4" -> {
+			case "3" -> saveDraft(controller, scanner);
+			case "4" -> save(controller, scanner);
+			case "5" -> {
 				System.out.println("Exiting this level editing session.");
 				running = false;
 			}
 			default -> System.out.println("Unknown command");
 			}
+		}
+	}
+
+	private boolean saveDraft(EditorController controller, Scanner scanner) {
+		System.out.print("DRAFT SAVE - File path to save (e.g. level1.json) ? ");
+		String filePath = scanner.nextLine();
+		try {
+			controller.saveDraftLevel(filePath);
+			return true;
+		} catch (IOException e) {
+			System.out.println("Impossible to access " + filePath);
+			return false;
 		}
 	}
 
@@ -88,8 +109,7 @@ public class EditorCli {
 		}
 	}
 
-	private LevelPrimaryData initialize() {
-		Scanner scanner = new Scanner(System.in);
+	private LevelPrimaryData initialize(Scanner scanner) {
 		LevelPrimaryData dimensions;
 		while (true) {
 			System.out.println("width (integer) ?");
@@ -107,16 +127,13 @@ public class EditorCli {
 			System.out.println("level description (string) ?");
 			cmd = scanner.nextLine();
 			String levelDescription = cmd;
-			System.out.println("recommanded difficulty (integer) ?");
-			cmd = scanner.nextLine();
-			int difficulty = Integer.parseInt(cmd);
 			System.out.println("player starting money (integer) ?");
 			cmd = scanner.nextLine();
 			int startingMoney = Integer.parseInt(cmd);
 			System.out.println("player starting lives (integer) ?");
 			cmd = scanner.nextLine();
 			int startingLives = Integer.parseInt(cmd);
-			dimensions = new LevelPrimaryData(width, height, levelId, levelName, levelDescription, difficulty,
+			dimensions = new LevelPrimaryData(width, height, levelId, levelName, levelDescription,
 					startingMoney, startingLives);
 			break;
 		}
@@ -140,9 +157,24 @@ public class EditorCli {
 		String filePath = scanner.nextLine();
 		try {
 			controller.loadLevel(filePath);
+			this.continueCreation(controller);
 			return true;
 		} catch (IOException e) {
 			System.out.println("Impossible to access " + filePath);
+			return false;
+		}
+	}
+	
+	private boolean loadDraft(EditorController controller, Scanner scanner) {
+		System.out.print("File path to load a draft level ? ");
+		String filePath = scanner.nextLine();
+		try {
+			controller.loadDraftLevel(filePath);
+			this.continueCreation(controller);
+			return true;
+		} catch (IOException e) {
+			System.out.println("Impossible to access " + filePath);
+			System.out.println(e);
 			return false;
 		}
 	}

--- a/td-level-editor/td-level-editor-ui/src/main/java/com/towerdefense/leveleditor/ui/EditorController.java
+++ b/td-level-editor/td-level-editor-ui/src/main/java/com/towerdefense/leveleditor/ui/EditorController.java
@@ -8,9 +8,12 @@ import com.towerdefense.editor.api.model.EditableLevel;
 import com.towerdefense.editor.api.model.LevelMetadata;
 import com.towerdefense.editor.api.model.PathDefinition;
 import com.towerdefense.editor.core.DefaultLevelEditor;
+import com.towerdefense.editor.core.exporter.EditableLevelExportService;
 import com.towerdefense.editor.core.exporter.LevelExportService;
-import com.towerdefense.editor.core.exporter.LevelJsonIO;
+import com.towerdefense.editor.core.importer.EditableLevelImportService;
 import com.towerdefense.editor.core.importer.LevelImportService;
+import com.towerdefense.editor.core.persistence.EditableLevelJsonIO;
+import com.towerdefense.editor.core.persistence.LevelJsonIO;
 import com.towerdefense.engine.api.model.configuration.LevelConfig;
 import com.towerdefense.leveleditor.ui.render.AsciiLevelRenderer;
 
@@ -19,14 +22,22 @@ public class EditorController {
 	private LevelEditor editor;
 	private final AsciiLevelRenderer renderer;
 	private final LevelJsonIO jsonIO;
-	private LevelImportService importService;
-	private LevelExportService exportService;
+	private final EditableLevelJsonIO editableLevelJsonIO;
+	private final LevelImportService importService;
+	private final LevelExportService exportService;
+	private final EditableLevelExportService editableLevelExportService;
+	private final EditableLevelImportService editableLevelImportService;
 
-	public EditorController(LevelJsonIO jsonIO, LevelImportService importService, LevelExportService exportService) {
+	public EditorController(LevelJsonIO jsonIO, EditableLevelJsonIO editableLevelJsonIO,
+			LevelImportService importService, LevelExportService exportService,
+			EditableLevelExportService editableLevelExportService, EditableLevelImportService editableLevelImportService) {
 		this.renderer = new AsciiLevelRenderer();
 		this.jsonIO = jsonIO;
+		this.editableLevelJsonIO = editableLevelJsonIO;
 		this.importService = importService;
 		this.exportService = exportService;
+		this.editableLevelExportService = editableLevelExportService;
+		this.editableLevelImportService = editableLevelImportService;
 	}
 
 	private void setEditor(LevelEditor editor) {
@@ -43,22 +54,42 @@ public class EditorController {
 
 	public void saveLevel(String filePath) throws IOException {
 		LevelConfig config = exportService.export(editor.getCurrentLevel());
-        jsonIO.save(config, Path.of(filePath));
+		jsonIO.save(config, Path.of(filePath));
 		System.out.println("Level saved to " + filePath);
 	}
 
-	public void loadLevel(String filePath) throws IOException {
+	public EditableLevel loadLevel(String filePath) throws IOException {
 		LevelConfig config = jsonIO.load(Path.of(filePath));
-        EditableLevel level = importService.importLevel(config);
-        editor.loadLevel(level);
+		EditableLevel level = importService.importLevel(config);
+		LevelEditor editor = new DefaultLevelEditor(level.getMetadata(), level.getMap().getWidth(), level.getMap().getHeight());
+		this.setEditor(editor);
+		editor.loadLevel(level);
 		System.out.println("Level loaded from " + filePath);
+		return level;
+	}
+	
+	public EditableLevel loadDraftLevel(String filePath) throws IOException {
+		EditableLevel currentlevel = editableLevelJsonIO.load(Path.of(filePath));
+		EditableLevel level = editableLevelImportService.importLevel(currentlevel);
+		LevelEditor editor = new DefaultLevelEditor(level.getMetadata(), level.getMap().getWidth(), level.getMap().getHeight());
+		this.setEditor(editor);
+		editor.loadLevel(level);
+		System.out.println("Draft level loaded from " + filePath);
+		return level;
 	}
 
 	public void createNewLevel(LevelPrimaryData data) {
 		LevelPrimaryData primaryData = data;
 		LevelMetadata metadata = new LevelMetadata(primaryData.levelId(), primaryData.name(), primaryData.description(),
-				primaryData.recommendedDifficulty(), primaryData.startingMoney(), primaryData.startingLives());
-		LevelEditor editor = new DefaultLevelEditor(metadata, primaryData.width(), primaryData.height());
-		this.setEditor(editor);
+				primaryData.startingMoney(), primaryData.startingLives());
+		LevelEditor internalEditor = new DefaultLevelEditor(metadata, primaryData.width(), primaryData.height());
+		this.setEditor(internalEditor);
+	}
+
+	public void saveDraftLevel(String filePath) throws IOException {
+		this.editableLevelExportService.export(editor.getCurrentLevel());
+		editableLevelJsonIO.save(editor.getCurrentLevel(), Path.of(filePath));
+		System.out.println("Draft level saved to " + filePath);
+
 	}
 }

--- a/td-level-editor/td-level-editor-ui/src/main/java/com/towerdefense/leveleditor/ui/LevelEditorMain.java
+++ b/td-level-editor/td-level-editor-ui/src/main/java/com/towerdefense/leveleditor/ui/LevelEditorMain.java
@@ -1,15 +1,20 @@
 package com.towerdefense.leveleditor.ui;
 
+import com.towerdefense.editor.core.exporter.EditableLevelExportService;
 import com.towerdefense.editor.core.exporter.LevelExportService;
-import com.towerdefense.editor.core.exporter.LevelJsonIO;
+import com.towerdefense.editor.core.importer.EditableLevelImportService;
 import com.towerdefense.editor.core.importer.LevelImportService;
+import com.towerdefense.editor.core.persistence.EditableLevelJsonIO;
+import com.towerdefense.editor.core.persistence.LevelJsonIO;
+import com.towerdefense.editor.core.validation.DefaultEditableLevelValidator;
 import com.towerdefense.editor.core.validation.DefaultLevelValidator;
 
 public class LevelEditorMain {
 
 	public static void main(String[] args) {
-		EditorController controller = new EditorController(new LevelJsonIO(), new LevelImportService(),
-				new LevelExportService(new DefaultLevelValidator()));
+		EditorController controller = new EditorController(new LevelJsonIO(), new EditableLevelJsonIO(),
+				new LevelImportService(), new LevelExportService(new DefaultLevelValidator()),
+				new EditableLevelExportService(new DefaultEditableLevelValidator()), new EditableLevelImportService());
 		EditorCli editorCli = new EditorCli();
 		editorCli.start(controller);
 	}

--- a/td-level-editor/td-level-editor-ui/src/main/java/com/towerdefense/leveleditor/ui/LevelPrimaryData.java
+++ b/td-level-editor/td-level-editor-ui/src/main/java/com/towerdefense/leveleditor/ui/LevelPrimaryData.java
@@ -1,6 +1,6 @@
 package com.towerdefense.leveleditor.ui;
 
-public record LevelPrimaryData(int width, int height, int levelId, String name, String description, int recommendedDifficulty, int startingMoney,
+public record LevelPrimaryData(int width, int height, int levelId, String name, String description, int startingMoney,
 		int startingLives) {
 
 }


### PR DESCRIPTION
#2 Ajout d'une capacité de sauvegarde et restauration d'un niveau brouillon pour reprendre un travail en cours.

Actuellement, les services EditableLevelExportService et EditableLevelImportService ne font que passe plat car ils n'ont pas de plus-value actuelle, mais ils pourraient servir demain à valider la cohérences des références externes par exemple ou ce genre de choses ... Au pire, ce n'est qu'un passe-plat de plus, mais ça permet aussi de garder une homogénéité avec la partie import/export de niveaux exportables